### PR TITLE
SharedPreference 사용

### DIFF
--- a/Airbnb/app/src/main/java/com/android/airbnb/login/LoginActivity.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/login/LoginActivity.java
@@ -18,6 +18,8 @@ import com.android.airbnb.WelcomeActivity;
 import com.android.airbnb.data.ApiService;
 import com.android.airbnb.domain.airbnb.LoginData;
 import com.android.airbnb.domain.airbnb.LoginResult;
+import com.android.airbnb.main.GuestMainActivity;
+import com.android.airbnb.util.PreferenceUtil;
 import com.android.airbnb.util.Remote.IServerApi;
 
 import okhttp3.MediaType;
@@ -107,8 +109,16 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
             @Override
             public void onResponse(Call<LoginResult> call, Response<LoginResult> response) {
                 Log.e("===============", "로그인 데이터 전송");
-                Log.e("===============", "Response" + response.body().token);
+                Log.e("===============", "Response Token : " + response.body().token);
 
+                // Token값 SharedPreference에 저장
+                PreferenceUtil.setToken(LoginActivity.this, response.body().token);
+
+                // 로그인 완료 후 메인화면으로 이동
+                Toast.makeText(LoginActivity.this, "Main 화면으로 이동합니다.", Toast.LENGTH_SHORT).show();
+                Intent intent = new Intent(LoginActivity.this, GuestMainActivity.class);
+                startActivity(intent);
+                finish();
             }
 
             @Override
@@ -130,7 +140,6 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                 break;
             case R.id.btnNextLoginEmail :
                 postLoginData();
-                Toast.makeText(LoginActivity.this, "메인 화면으로 이동", Toast.LENGTH_SHORT).show();
                 break;
             case R.id.btnUseTel :
                 Toast.makeText(LoginActivity.this, "전화번호 사용 버튼 클릭", Toast.LENGTH_SHORT).show();

--- a/Airbnb/app/src/main/java/com/android/airbnb/main/GuestMainActivity.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/main/GuestMainActivity.java
@@ -6,13 +6,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 import com.android.airbnb.R;
+import com.android.airbnb.util.PreferenceUtil;
 
 import static com.android.airbnb.R.id.main_container;
 
 public class GuestMainActivity extends AppCompatActivity {
 
     private GuestSearchFragment guestSearchFragment;
-    private WishListDetailFragment wishFragment;
+    private GuestWishListDetailFragment wishFragment;
     private GuestTravelFragment guestTravelFragment;
     private GuestMessageFragment guestMessageFragment;
     private GuestProfileFragment guestProfileFragment;
@@ -32,6 +33,7 @@ public class GuestMainActivity extends AppCompatActivity {
         setFragments();
         setViews();
         setListeners();
+        Log.e("Main에서 token값 확인", PreferenceUtil.getToken(this)+"");
     }
 
     private void setViews(){
@@ -96,7 +98,7 @@ public class GuestMainActivity extends AppCompatActivity {
 
     private void setFragments(){
         guestSearchFragment = new GuestSearchFragment();
-        wishFragment = new WishListDetailFragment();
+        wishFragment = new GuestWishListDetailFragment();
         guestTravelFragment = new GuestTravelFragment();
         guestMessageFragment = new GuestMessageFragment();
         guestProfileFragment = new GuestProfileFragment();

--- a/Airbnb/app/src/main/java/com/android/airbnb/main/GuestProfileFragment.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/main/GuestProfileFragment.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.constraint.ConstraintLayout;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +15,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.android.airbnb.R;
+import com.android.airbnb.util.PreferenceUtil;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -43,6 +45,7 @@ public class GuestProfileFragment extends Fragment implements View.OnClickListen
         View view = inflater.inflate(R.layout.fragment_guest_profile, container, false);
         setViews(view);
         setListeners();
+        Log.e("Profile에서 token값 확인", PreferenceUtil.getToken(getActivity())+"");
         return view;
     }
 

--- a/Airbnb/app/src/main/java/com/android/airbnb/main/GuestWishListDetailFragment.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/main/GuestWishListDetailFragment.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * A simple {@link Fragment} subclass.
  */
-public class WishListDetailFragment extends Fragment implements ITask {
+public class GuestWishListDetailFragment extends Fragment implements ITask {
 
     private GuestMainActivity guestMainActivity;
     private TextView txtTitle;
@@ -48,9 +48,9 @@ public class WishListDetailFragment extends Fragment implements ITask {
     private WishListDetailAdapter adapter;
     private List<House> houseList;
     private ImageView btnFilter;
-    private WistListFragment wishListFragment;
+    private GuestWistListFragment wishListFragment;
 
-    public WishListDetailFragment() {
+    public GuestWishListDetailFragment() {
         // Required empty public constructor
     }
 
@@ -71,7 +71,7 @@ public class WishListDetailFragment extends Fragment implements ITask {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_wish, container, false);
+        View view = inflater.inflate(R.layout.fragment_guest_wish, container, false);
         setViews(view);
         setToolbar();
         setListeners();

--- a/Airbnb/app/src/main/java/com/android/airbnb/main/GuestWistListFragment.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/main/GuestWistListFragment.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * A simple {@link Fragment} subclass.
  */
-public class WistListFragment extends Fragment {
+public class GuestWistListFragment extends Fragment {
 
     private List<House> houseList;
     private RecyclerView wishlistListRecycler;
@@ -28,7 +28,7 @@ public class WistListFragment extends Fragment {
     public GuestMainActivity guestMainActivity;
 
 
-    public WistListFragment() {
+    public GuestWistListFragment() {
         // Required empty public constructor
     }
 
@@ -55,7 +55,7 @@ public class WistListFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         if (view == null) {
-            view = inflater.inflate(R.layout.fragment_wist_list, container, false);
+            view = inflater.inflate(R.layout.fragment_guest_wist_list, container, false);
         }
         setViews();
         return view;

--- a/Airbnb/app/src/main/java/com/android/airbnb/main/SettingActivity.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/main/SettingActivity.java
@@ -15,6 +15,7 @@ import android.widget.Toast;
 import com.android.airbnb.R;
 import com.android.airbnb.WelcomeActivity;
 import com.android.airbnb.data.ApiService;
+import com.android.airbnb.util.PreferenceUtil;
 import com.android.airbnb.util.Remote.IServerApi;
 
 import okhttp3.ResponseBody;
@@ -82,9 +83,7 @@ public class SettingActivity extends AppCompatActivity implements View.OnClickLi
                 .build();
         iServerApi = retrofit.create(IServerApi.class);
 
-        Log.e("========", "로그 확인 1");
-
-        Call<ResponseBody> getLogout = iServerApi.getLogout("Token 01f2768f0806f501eed7d0d81d83331b2d3c4480");
+        Call<ResponseBody> getLogout = iServerApi.getLogout("Token " + PreferenceUtil.getToken(this));
         getLogout.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {

--- a/Airbnb/app/src/main/java/com/android/airbnb/signup/SignUpBeforeFragment.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/signup/SignUpBeforeFragment.java
@@ -16,7 +16,7 @@ import android.widget.Toast;
 import com.android.airbnb.R;
 import com.android.airbnb.data.ApiService;
 import com.android.airbnb.domain.airbnb.SignUpData;
-import com.android.airbnb.main.GuestMainActivity;
+import com.android.airbnb.login.LoginActivity;
 import com.android.airbnb.util.Remote.IServerApi;
 
 import java.util.List;
@@ -27,6 +27,7 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -79,7 +80,7 @@ public class SignUpBeforeFragment extends Fragment implements View.OnClickListen
     private void postSignUpData(){
         retrofit = new Retrofit.Builder()
                 .baseUrl(ApiService.API_URL)
-                //.addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(GsonConverterFactory.create())
                 .build();
         iServerApi = retrofit.create(IServerApi.class);
 
@@ -103,8 +104,9 @@ public class SignUpBeforeFragment extends Fragment implements View.OnClickListen
                 Log.e("==============" , "데이터 전송");
                 // response.toString() 을 로그에 찍어보면 response 결과를 바로 로그창에서 볼 수 있음
                 Log.e("================", response.toString());
-                Toast.makeText(signUpActivity.getBaseContext(), "회원가입이 완료되었습니다.\nMain 화면으로 이동합니다.", Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(signUpActivity.getBaseContext(), GuestMainActivity.class);
+                Log.e("================", response.body().getBirthday());
+                Toast.makeText(signUpActivity.getBaseContext(), "회원가입이 완료되었습니다.\n로그인 화면으로 이동합니다.", Toast.LENGTH_SHORT).show();
+                Intent intent = new Intent(signUpActivity.getBaseContext(), LoginActivity.class);
                 startActivity(intent);
                 signUpActivity.finish();
             }

--- a/Airbnb/app/src/main/java/com/android/airbnb/util/PreferenceUtil.java
+++ b/Airbnb/app/src/main/java/com/android/airbnb/util/PreferenceUtil.java
@@ -1,0 +1,37 @@
+package com.android.airbnb.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Created by MDY on 2017-08-09.
+ */
+
+public class PreferenceUtil {
+    private static SharedPreferences sharedPreferences = null;
+
+    private static void setSharedPreferences(Context context){
+        if(sharedPreferences == null)
+            sharedPreferences = context.getSharedPreferences("settings", Context.MODE_PRIVATE); // MODE_PRIVATE - 다른 앱이 접근하지 못하게
+    }
+
+    private static void setString(Context context, String key, String value){
+        setSharedPreferences(context);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString(key, value);
+        editor.commit();
+    }
+
+    private static String getString(Context context, String key){
+        setSharedPreferences(context);
+        return sharedPreferences.getString(key, "해당 데이터 없음");
+    }
+
+    // token
+    public static void setToken(Context context, String token){
+        setString(context,"userToken", token);
+    }
+    public static String getToken(Context context) {
+        return getString(context, "userToken");
+    }
+}

--- a/Airbnb/app/src/main/res/layout/fragment_guest_wish.xml
+++ b/Airbnb/app/src/main/res/layout/fragment_guest_wish.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    tools:context="com.android.airbnb.main.WishListDetailFragment">
+    tools:context="com.android.airbnb.main.GuestWishListDetailFragment">
 
     <android.support.design.widget.AppBarLayout
         android:id="@+id/layout_toolbar"

--- a/Airbnb/app/src/main/res/layout/fragment_guest_wist_list.xml
+++ b/Airbnb/app/src/main/res/layout/fragment_guest_wist_list.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    tools:context="com.android.airbnb.main.WistListFragment">
+    tools:context="com.android.airbnb.main.GuestWistListFragment">
 
     <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"


### PR DESCRIPTION
1. WishList관련 Fragment 및 Layout 이름 변경 (Guest쪽에서 사용하는 것임을 명시하기 위해)
2. PreferenceUtil 작성 (로그인 시, token값 저장을 위해서)
3. SharedPreference 코드 작성 (Login시 새로 생성되는 token값을 SharedPreference에 저장하고, Logout시 token값을 헤더에 넣어 보내 기존 token값을 삭제한다.)